### PR TITLE
chromium: Fix passing flag arguments to chromium binary

### DIFF
--- a/debian-docker-images/imx/chromium/start-chromium.sh
+++ b/debian-docker-images/imx/chromium/start-chromium.sh
@@ -39,7 +39,7 @@ do
         shift
         ;;
     --*)
-      chromium_extended_params="$chromium_extended_params $1"
+      chromium_parms_extended="$chromium_parms_extended $1"
       shift
       ;;
     *)


### PR DESCRIPTION
If I am understanding the branching correctly, this "oldstable" branch is for the version 3 containers.  It seems the logic for passing arbitrary options into chromium had an [error introduced](https://github.com/torizon/torizon-containers/commit/bbc8c190f77791041ba8417e072e844934aadaa7#diff-287daecfd18a4dcfa8b22606d86a8c2af5247aed2cba856d2cbd845a5d693fe8R42).  It seems the am62 version of this script uses the name `chromium_extended_params` while the IMX version uses `chromium_parms_extended`