### PR TITLE
wayland-base: am62: Add libwayland-cursor0

### DIFF
--- a/platform-specific/am62/wayland-base/Dockerfile
+++ b/platform-specific/am62/wayland-base/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get -y update && apt-get install -y \
     libwayland-egl1-mesa \
     libwayland-client0 \
     libwayland-server0 \
+    libwayland-cursor0 \
     mesa-utils-extra \
     mesa-common-dev \
     mesa-opencl-icd \


### PR DESCRIPTION
Fixes: https://github.com/torizon/torizon-containers/issues/15